### PR TITLE
Fix npm bin target

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Pokemon terminal themes",
   "bin": {
-    "pokemon": "pokemon"
+    "pokemon": "main.py"
   },
   "scripts": {},
   "repository": {


### PR DESCRIPTION
I believe the problem was that npm didn't like the symlink. It's difficult to test locally, the best you can do is `npm link` which doesn't 100% simulate a global install. However, this _should_ fix the problem, since it now points directly to the main script instead of a symlink.