### PR TITLE
Use a multiline string to simplify the OSA script

### DIFF
--- a/adapter/implementations/ITerm.py
+++ b/adapter/implementations/ITerm.py
@@ -3,6 +3,12 @@ import subprocess
 
 from adapter.base import TerminalAdapterInterface
 
+osa_script_fmt = """tell application "iTerm"
+\ttell current session of current window
+\t\tset background image to "{}"
+\tend tell
+end tell"""
+
 
 class ITerm(TerminalAdapterInterface):
     @staticmethod
@@ -11,12 +17,7 @@ class ITerm(TerminalAdapterInterface):
 
     def __generate_osascript(self, path):
         # Create the content for script that will change the terminal background image.
-        content = "tell application \"iTerm\"\n"
-        content += "\ttell current session of current window\n"
-        content += "\t\tset background image to \"" + path + "\"\n"
-        content += "\tend tell\n"
-        content += "end tell"
-        return content
+        return osa_script_fmt.format(path)
 
     def __run_osascript(self, stream):
         p = subprocess.Popen(['osascript'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)

--- a/adapter/implementations/ITerm.py
+++ b/adapter/implementations/ITerm.py
@@ -3,6 +3,7 @@ import subprocess
 
 from adapter.base import TerminalAdapterInterface
 
+# OSA script that will change the terminal background image
 osa_script_fmt = """tell application "iTerm"
 \ttell current session of current window
 \t\tset background image to "{}"
@@ -15,10 +16,6 @@ class ITerm(TerminalAdapterInterface):
     def is_available():
         return os.environ.get("ITERM_PROFILE")
 
-    def __generate_osascript(self, path):
-        # Create the content for script that will change the terminal background image.
-        return osa_script_fmt.format(path)
-
     def __run_osascript(self, stream):
         p = subprocess.Popen(['osascript'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         p.stdin.write(stream)
@@ -26,7 +23,7 @@ class ITerm(TerminalAdapterInterface):
         p.stdin.close()
 
     def set_pokemon(self, pokemon):
-        stdin = self.__generate_osascript(pokemon.get_path())
+        stdin = osa_script_fmt.format(pokemon.get_path())
         self.__run_osascript(str.encode(stdin))
 
     def clear(self):


### PR DESCRIPTION
Triple quoted strings allow you to create multi line content in a more readable way.