### PR TITLE
Every Pokemon object should have a dark_threshold

### DIFF
--- a/database.py
+++ b/database.py
@@ -99,6 +99,16 @@ class Database:
         # Get all the Extra Pokemon images available.
         return self.__get_region(None)
 
+    def get_light(self, threshold=0.4, all=False):
+        light = [pokemon.__name for pokemon in self.__pokemon_list
+                 if pokemon.dark_threshold > threshold]
+        return light if all else random.choice(light)
+
+    def get_dark(self, threshold=0.6, all=False):
+        dark = [pokemon.__name for pokemon in self.__pokemon_list
+                if pokemon.dark_threshold < threshold]
+        return dark if all else random.choice(dark)
+
     def __get_region(self, region):
         # Helper method for getting all the Pokemon of a specified region.
         return [pokemon for pokemon in self.__pokemon_list

--- a/database.py
+++ b/database.py
@@ -11,11 +11,12 @@ class Pokemon:
     __path = ""  # The location of the image.
     __dark_threshold = 0.5
 
-    def __init__(self, identifier, name, region, path):
+    def __init__(self, identifier, name, region, path, dark_treshold):
         self.__id = identifier
         self.__name = name
         self.__region = region
         self.__path = path
+        self.__dark_treshold = dark_treshold
 
     def get_id(self):
         # Pokemon from folder 'Extra' have no ID.
@@ -29,6 +30,10 @@ class Pokemon:
 
     def get_path(self):
         return self.__path
+
+    @property
+    def dark_treshold(self):
+        return self.__dark_treshold
 
     def is_extra(self):
         return self.__id is None
@@ -162,7 +167,8 @@ class Database:
                 identifier = '{:03}'.format(int(identifier))
                 region = self.__determine_region(identifier)
                 path = self.__determine_folder(identifier) + "/" + identifier + ".jpg"
-                pokemon = Pokemon(identifier, name.lower(), region, path)
+                dark_treshold = 0.5  # TODO: fix me
+                pokemon = Pokemon(identifier, name.lower(), region, path, dark_treshold)
                 self.__pokemon_list.append(pokemon)
                 self.__pokemon_dictionary[pokemon.get_name()] = pokemon
 
@@ -172,7 +178,8 @@ class Database:
             if file.endswith(".jpg"):
                 name = os.path.join("/Images/Extra", file).split('/')[-1][0:-4].lower()
                 path = self.directory + "/./Images/Extra/" + name + ".jpg"
-                pokemon = Pokemon(None, name, None, path)
+                dark_treshold = 0.5  # TODO: fix me
+                pokemon = Pokemon(None, name, None, path, dark_treshold)
                 if name in self.__pokemon_dictionary:
                     raise Exception("Duplicate names detected. "
                                     "The name of the file " + str(name) + ".jpg in the folder 'Extra' must be changed.")

--- a/database.py
+++ b/database.py
@@ -9,6 +9,7 @@ class Pokemon:
     __name = ""
     __region = ""
     __path = ""  # The location of the image.
+    __dark_threshold = 0.5
 
     def __init__(self, identifier, name, region, path):
         self.__id = identifier

--- a/database.py
+++ b/database.py
@@ -161,13 +161,13 @@ class Database:
 
     def __load_data(self):
         # Load all the Pokemon data. This does not include the 'Extra' Pokemon.
-        with open(self.directory + "/./Data/pokemon.txt", 'r') as data_file:
-            for line in data_file:  # Load everything but the Pokemon from the 'Extra' folder.
-                identifier, _, name = line.strip().partition(' ')
-                identifier = '{:03}'.format(int(identifier))
-                region = self.__determine_region(identifier)
-                path = self.__determine_folder(identifier) + "/" + identifier + ".jpg"
-                dark_treshold = 0.5  # TODO: fix me
+        with open(self.directory + "/./Data/light-dark.txt", 'r') as data_file:
+            for i, line in enumerate(data_file):  # Load everything but the Pokemon from the 'Extra' folder.
+                name, _, dark_treshold = line.strip().partition(' ')
+                id = i + 1  # zero-based indexing --> one-based sequence numbers
+                identifier = '{:03}'.format(id)  # zero padded string
+                region = self.__determine_region(id)
+                path = self.__determine_folder(id) + "/" + identifier + ".jpg"
                 pokemon = Pokemon(identifier, name.lower(), region, path, dark_treshold)
                 self.__pokemon_list.append(pokemon)
                 self.__pokemon_dictionary[pokemon.get_name()] = pokemon
@@ -178,7 +178,7 @@ class Database:
             if file.endswith(".jpg"):
                 name = os.path.join("/Images/Extra", file).split('/')[-1][0:-4].lower()
                 path = self.directory + "/./Images/Extra/" + name + ".jpg"
-                dark_treshold = 0.5  # TODO: fix me
+                dark_treshold = 0.5  # TODO: what should this be for an extra?
                 pokemon = Pokemon(None, name, None, path, dark_treshold)
                 if name in self.__pokemon_dictionary:
                     raise Exception("Duplicate names detected. "


### PR DESCRIPTION
Every Pokemon object should have its own `.__dark_threshold` attribute.  This could be read in and set once in `Database.__load_data()`(reading `light-dark.txt` instead of `pokemon.txt`) which would simplify the `get_light()` and `get_dark()` logic.