### PR TITLE
Move list, dict from class level to instance level

### DIFF
--- a/database.py
+++ b/database.py
@@ -61,8 +61,6 @@ class Pokemon:
 
 class Database:
     """The Database object is a container for all the supported Pokemon."""
-    __pokemon_list = []
-    __pokemon_dictionary = {}
     __pokemon_type_dictionary = {}
     __POKEMON_TYPES = ('normal', 'fire', 'fighting', 'water', 'flying',
                        'grass', 'poison', 'electric', 'ground', 'psychic',
@@ -73,6 +71,8 @@ class Database:
     __regions = ('kanto', 'johto', 'hoenn', 'sinnoh')
 
     def __init__(self):
+        self.__pokemon_list = []
+        self.__pokemon_dictionary = {}
         self.directory = os.path.dirname(os.path.realpath(__file__))
         for pkmn_t in self.__POKEMON_TYPES:
             self.__pokemon_type_dictionary[pkmn_t] = []

--- a/database.py
+++ b/database.py
@@ -61,7 +61,6 @@ class Pokemon:
 
 class Database:
     """The Database object is a container for all the supported Pokemon."""
-    __pokemon_type_dictionary = {}
     __POKEMON_TYPES = ('normal', 'fire', 'fighting', 'water', 'flying',
                        'grass', 'poison', 'electric', 'ground', 'psychic',
                        'rock', 'ice', 'bug', 'dragon', 'ghost', 'dark',
@@ -73,6 +72,7 @@ class Database:
     def __init__(self):
         self.__pokemon_list = []
         self.__pokemon_dictionary = {}
+        self.__pokemon_type_dictionary = {}
         self.directory = os.path.dirname(os.path.realpath(__file__))
         for pkmn_t in self.__POKEMON_TYPES:
             self.__pokemon_type_dictionary[pkmn_t] = []


### PR DESCRIPTION
Creating two instances of the Database class throws `Exception: Duplicate names detected.`

You can see this by running the code:
```python
db0 = Database()  # create the first db... no problems
db1 = Database()  # Exception: Duplicate names detected
```

This is caused because all instances of a class share a single copy of all class level variables.  This means that when db1 wants to add a pokemon to the list, it sees that db0 has already added it.  Class-level variables are good for constants but in general should be avoided for things that get modified at runtime (unless shared state between all instances is desirable and collisions like this are carefully guarded against).

This is a problem because pytest will create multiple database instances as it sets up, executes, and tears down tests of various aspects of the app.  The cleanest fix to this problem that I can think of is to demote the list and dict from being class level to being instance level variables.  This way each instance has its own separate copy and we reduce shared state.