### PR TITLE
Create the pokemon_list outside of the Database (round II)

### DIFF
--- a/load_all_pokemon.py
+++ b/load_all_pokemon.py
@@ -67,9 +67,9 @@ def make_an_extra_pokemon(filename, in_ext='.jpg'):
     assert False, 'Bad file extention: {} != {}'.format(ext, in_ext)
 
 
-def load_extra():
+def load_extra(image_dir=None):
     """Load all the file names of the images in the Extra folder."""
-    filenames = os.listdir(EXTRA_DIR)
+    filenames = os.listdir(image_dir or EXTRA_DIR)
     return [make_an_extra_pokemon(filename) for filename in filenames]
 
 

--- a/load_all_pokemon.py
+++ b/load_all_pokemon.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+import collections
+import os
+from database import Pokemon
+
+SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+DATA_DIR = os.path.join(SCRIPT_DIR, 'Data')
+IMAGES_DIR = os.path.join(SCRIPT_DIR, 'Images')
+EXTRA_DIR = os.path.join(IMAGES_DIR, 'Extra')
+
+region_info = collections.namedtuple('region_info', 'start end dir_name')
+region_dict = {
+    'kanto': region_info(1, 151, 'Generation I - Kanto'),
+    'johto': region_info(152, 251, 'Generation II - Johto'),
+    'hoenn': region_info(252, 386, 'Generation III - Hoenn'),
+    'sinnoh': region_info(387, 493, 'Generation IV - Sinnoh'),
+    'extra': region_info(0, 0, 'Extra')
+}
+
+g_pokemon_dict = None  # potential fathers for extra pokemon
+
+
+def region_name_by_id(id):
+    if not id:
+        return 'extra'
+    for name, region in region_dict.items():
+        if region.start <= int(id) <= region.end:
+            return name
+    assert False, 'region_name_by_id({})'.format(id)
+
+
+def make_a_pokemon(i, line):
+    id = '{:03}'.format(i + 1)
+    line = line.strip().split()
+    while len(line) < 4:  # add '' as the subtype if it is missing
+        line.append('')
+    name, threshold, main_type, subtype = line
+    name = name.lower()
+    threshold = float(threshold)
+    region = region_name_by_id(id)
+    dir_name = region_dict[region].dir_name
+    path = os.path.join(IMAGES_DIR, dir_name, id + '.jpg')
+    return Pokemon(id, name, region, path, main_type, subtype, threshold)
+
+
+def load_pokemon(filename='pokemon.txt'):
+    """Load everything but the Pokemon from the 'Extra' folder"""
+    with open(os.path.join(DATA_DIR, filename)) as in_file:
+        return [make_a_pokemon(i, line) for i, line in enumerate(in_file)]
+
+
+def make_an_extra_pokemon(filename, in_ext='.jpg'):
+    name, ext = os.path.splitext(filename)
+    if ext.lower() == in_ext:
+        name = name.lower()
+        path = os.path.join(EXTRA_DIR, filename)
+        father = g_pokemon_dict.get(name.split('-')[0])
+        if father:
+            return Pokemon(None, name,
+                           father.get_region(), path,
+                           father.get_pkmn_type(),
+                           father.get_pkmn_type_secondary(),
+                           father.get_dark_threshold())
+        else:
+            return Pokemon(None, name, None, path, None, None, None)
+    assert False, 'Bad file extention: {} != {}'.format(ext, in_ext)
+
+
+def load_extra():
+    """Load all the file names of the images in the Extra folder."""
+    filenames = os.listdir(EXTRA_DIR)
+    return [make_an_extra_pokemon(filename) for filename in filenames]
+
+
+def load_all_pokemon():
+    global g_pokemon_dict
+    pokemon_list = load_pokemon()
+    g_pokemon_dict = {pokemon.get_name(): pokemon for pokemon in pokemon_list}
+    return pokemon_list + load_extra()
+
+
+if __name__ == '__main__':
+    pokemon_list = load_all_pokemon()
+    pokemon_dict = {pokemon.get_name(): pokemon for pokemon in pokemon_list}
+    print(len(pokemon_list), len(set(pokemon_list)), len(pokemon_dict))
+    for i in (0, -1):
+        pokemon = pokemon_list[i]
+        print(pokemon.is_extra(), pokemon)

--- a/load_all_pokemon.py
+++ b/load_all_pokemon.py
@@ -30,8 +30,8 @@ def region_name_by_id(id):
     assert False, 'region_name_by_id({})'.format(id)
 
 
-def make_a_pokemon(i, line):
-    id = '{:03}'.format(i + 1)
+def make_a_pokemon(id, line):
+    id = '{:03}'.format(id)
     line = line.strip().split()
     while len(line) < 4:  # add '' as the subtype if it is missing
         line.append('')
@@ -47,7 +47,7 @@ def make_a_pokemon(i, line):
 def load_pokemon(filename='pokemon.txt'):
     """Load everything but the Pokemon from the 'Extra' folder"""
     with open(os.path.join(DATA_DIR, filename)) as in_file:
-        return [make_a_pokemon(i, line) for i, line in enumerate(in_file)]
+        return [make_a_pokemon(i, line) for i, line in enumerate(in_file, 1)]
 
 
 def make_an_extra_pokemon(filename, in_ext='.jpg'):

--- a/test_load.py
+++ b/test_load.py
@@ -4,8 +4,8 @@
 
 from database import Database, Pokemon
 from load_all_pokemon import load_all_pokemon
-# from test_utils import region_dict, get_region, make_extra_counts, MAX_ID
-MAX_ID = 493  # FixMe once #82 is accepted
+from test_utils import region_dict, get_region, make_extra_counts, MAX_ID
+# MAX_ID = 493  # FixMe once #82 is accepted
 EXTRA_COUNT = 24  # FixMe once #82 is accepted
 
 

--- a/test_load.py
+++ b/test_load.py
@@ -4,9 +4,7 @@
 
 from database import Database, Pokemon
 from load_all_pokemon import load_all_pokemon
-from test_utils import region_dict, get_region, make_extra_counts, MAX_ID
-# MAX_ID = 493  # FixMe once #82 is accepted
-EXTRA_COUNT = 24  # FixMe once #82 is accepted
+from test_utils import expected_len, MAX_ID
 
 
 def compare_pokemon(a, b):
@@ -23,7 +21,7 @@ def compare_pokemon(a, b):
 
 
 def test_len():
-    assert len(Database()) == len(load_all_pokemon()) == MAX_ID + EXTRA_COUNT
+    assert len(Database()) == len(load_all_pokemon()) == MAX_ID + expected_len('extra')
 
 
 def test_lists():

--- a/test_load.py
+++ b/test_load.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+# To run the tests, use: python3 -m pytest --capture=sys
+
+from database import Database, Pokemon
+from load_all_pokemon import load_all_pokemon
+# from test_utils import region_dict, get_region, make_extra_counts, MAX_ID
+MAX_ID = 493  # FixMe once #82 is accepted
+EXTRA_COUNT = 24  # FixMe once #82 is accepted
+
+
+def compare_pokemon(a, b):
+    assert isinstance(a, Pokemon)
+    assert isinstance(b, Pokemon)
+    assert a.get_id() == b.get_id()
+    assert a.get_name() == b.get_name()
+    assert a.get_region() == b.get_region()
+    assert a.get_path() == b.get_path()
+    assert a.get_dark_threshold() == b.get_dark_threshold()
+    assert a.get_pkmn_type() == b.get_pkmn_type()
+    assert a.get_pkmn_type_secondary() == b.get_pkmn_type_secondary()
+    # print(a.get_name())
+
+
+def test_len():
+    assert len(Database()) == len(load_all_pokemon()) == MAX_ID + EXTRA_COUNT
+
+
+def test_lists():
+    db = Database()
+    load_list = load_all_pokemon()
+    for db_p, load_p in zip(db.get_all(), load_list):
+        assert str(db_p) == str(load_p)
+        compare_pokemon(db_p, load_p)
+        # db_p != load_p but the hidden __attributes stifle complete testing
+        # assert db_p == load_p, '\n{}\n{}'.format(db_p, load_p)
+    # the lists are not identical but hidden __attributes stifle complete tests
+    # assert db.get_all() == load_list
+
+
+if __name__ == '__main__':
+    # Test runner: Runs all functions whose name begins with `test_`
+    # locals() changes when trying to do this without the list comprehension!!!
+    name_funcs = [(n, f) for n, f in locals().items() if n.startswith('test_')]
+    for name, func in name_funcs:
+        if callable(func):
+            func()
+        else:
+            print(name + ' is not callable()!')


### PR DESCRIPTION
A second attempt at #73 **without** the tuple store idea...  As discussed in #73, my sense is that a separate `load_all_pokemon.py` file that manages reading the data files and creating a list of all pokemon (standard + extra) would help a lot.

This PR is trying to isolate the complexity of the data ingestion process which is currently too intertwined with the rest of the database implementation.  This also thwarts our ability to run tests.

`load_all_pokemon.py` exposes one function: `load_all_pokemon()` that returns a pokemon_list.  This way when we create a new Database, we could pass in an already prepared pokemon_list.  For testing purposes, we can even pass in a different pokemon_list with bad values, etc. to see how Database() behaves in the face of garbage data.

`Database.__init__()` can create the other data structures that it needs from the pokemon_list.
For example in `database.py`...
```python
from load_all_pokemon import load_all_pokemon

class Database:
    def __init__(self, pokemon_list=None):
        self.__pokemon_list = pokemon_list or load_all_pokemon()
        assert self.__pokemon_list, 'Failed to load the Pokemon list!!'
        self.__pokemon_dict = {p.get_name(): p for p in self.__pokemon_list}
        assert len(self.__pokemon_list) == len(self.__pokemon_dict), 'DuplicateErr'
        self.__pokemon_type_dictionary =  # [ ... ]
```