### PR TITLE
Implements adapter pattern to wallpappers

### DIFF
--- a/pokemonterminal/scripter.py
+++ b/pokemonterminal/scripter.py
@@ -43,7 +43,7 @@ def change_wallpaper(image_file_path):
                 print("Invalid number, try again!")
         target = providers[inp]
     elif len(providers) <= 0:
-        print("Your desktop environment isn't supported by this time.")
+        print("Your desktop environment isn't supported at this time.")
         sys.exit()
     else:
         target = providers[0]

--- a/pokemonterminal/scripter.py
+++ b/pokemonterminal/scripter.py
@@ -4,6 +4,37 @@ import sys
 from pokemonterminal.adapter import identify
 from .wallpaper import get_current_adapters
 
+WALLPAPER_PROVIDER = None
+
+
+def __init_wallpaper_provider():
+    global WALLPAPER_PROVIDER
+    if WALLPAPER_PROVIDER is not None:
+        return
+    providers = get_current_adapters()
+    if len(providers) > 1:
+        # All this if is really not supposed to happen at all whatsoever
+        # really what kind of person has 2 simultaneous D.E???
+        print("Multiple providers found select the appropriate one:")
+        [print(str(x)) for x in providers]
+        print("If some of these make no sense or are irrelevant please file" +
+              "an issue in https://github.com/LazoCoder/Pokemon-Terminal")
+        print("=> ", end='')
+        inp = None
+        while inp is None:
+            try:
+                inp = int(input())
+                if inp >= len(providers):
+                    raise ValueError()
+            except ValueError as _:
+                print("Invalid number, try again!")
+        WALLPAPER_PROVIDER = providers[inp]
+    elif len(providers) <= 0:
+        print("Your desktop environment isn't supported at this time.")
+        sys.exit()
+    else:
+        WALLPAPER_PROVIDER = providers[0]
+
 
 def clear_terminal():
     adapter = identify()
@@ -24,27 +55,5 @@ def change_wallpaper(image_file_path):
     if not isinstance(image_file_path, str):
         print("A image path must be passed to the change wallpapper function.")
         return
-    providers = get_current_adapters()
-    if len(providers) > 1:
-        # All this if is really not supposed to happen at all whatsoever
-        # really what kind of person has 2 simultaneous D.E???
-        print("Multiple providers found select the appropriate one:")
-        [print(str(x)) for x in providers]
-        print("If some of these make no sense or are irrelevant please file" +
-              "an issue in https://github.com/LazoCoder/Pokemon-Terminal")
-        print("=> ", end='')
-        inp = None
-        while inp is None:
-            try:
-                inp = int(input())
-                if inp >= len(providers):
-                    raise ValueError()
-            except ValueError as _:
-                print("Invalid number, try again!")
-        target = providers[inp]
-    elif len(providers) <= 0:
-        print("Your desktop environment isn't supported at this time.")
-        sys.exit()
-    else:
-        target = providers[0]
-    target.change_wallpaper(image_file_path)
+    __init_wallpaper_provider()
+    WALLPAPER_PROVIDER.change_wallpaper(image_file_path)

--- a/pokemonterminal/wallpaper/__init__.py
+++ b/pokemonterminal/wallpaper/__init__.py
@@ -11,6 +11,11 @@ def _is_adapter(member) -> bool:
 
 
 def _get_adapter_classes() -> [WallpaperProvider]:
+    """
+    This methods reads all the modules in the adapters folder searching for
+    all the implementing wallpaper adapter classes
+    thanks for/adapted from https://github.com/cclauss/adapter_pattern/
+    """
     dirname = os.path.join(os.path.dirname(
         os.path.abspath(__file__)), 'adapters')
     adapter_classes = []

--- a/pokemonterminal/wallpaper/__init__.py
+++ b/pokemonterminal/wallpaper/__init__.py
@@ -1,0 +1,29 @@
+import os
+import importlib
+import inspect
+from .adapters import WallpaperProvider
+
+
+def _is_adapter(member) -> bool:
+    return (inspect.isclass(member)
+            and issubclass(member, WallpaperProvider)
+            and member != WallpaperProvider)
+
+
+def _get_adapter_classes() -> [WallpaperProvider]:
+    dirname = os.path.join(os.path.dirname(
+        os.path.abspath(__file__)), 'adapters')
+    adapter_classes = []
+    for file_name in sorted(os.listdir(dirname)):
+        root, ext = os.path.splitext(file_name)
+        if ext.lower() == '.py' and not root.startswith('__'):
+            module = importlib.import_module(
+                '.' + root, 'pokemonterminal.wallpaper.adapters')
+            for _, c in inspect.getmembers(module, _is_adapter):
+                adapter_classes.append(c)
+    return adapter_classes
+
+
+def get_current_adapters() -> [WallpaperProvider]:
+    arr = _get_adapter_classes()
+    return [x for x in arr if x.is_compatible()]

--- a/pokemonterminal/wallpaper/adapters/__init__.py
+++ b/pokemonterminal/wallpaper/adapters/__init__.py
@@ -1,0 +1,21 @@
+class WallpaperProvider:
+    """
+    Interface representing all the different desktop environments supported
+    by pokemon-terminal if you want to implement a DE, create a module in this
+    folder that implements this interface, reflection will do the rest.
+    """
+
+    def change_wallpaper(path: str):
+        """
+        This sets the wallpaper of the corresponding D.E of this adapter.
+        :param path The full path of the required pokemon image
+        """
+        raise NotImplementedError()
+
+    def is_compatible() -> bool:
+        """
+        checks for compatibility
+        :return a boolean saying whether or not the current adaptor is
+        compatible with the running D.E
+        """
+        raise NotImplementedError()

--- a/pokemonterminal/wallpaper/adapters/darwin.py
+++ b/pokemonterminal/wallpaper/adapters/darwin.py
@@ -1,9 +1,9 @@
-from . import WallpaperProvider as _WProv
+from . import WallpaperProvider as __WProv
 import subprocess as __sp
 import sys as __sys
 
 
-class DarwinProvider(_WProv):
+class DarwinProvider(__WProv):
     __osa_script_fmt = """tell application "System Events"
     \ttell current desktop
     \t\tset picture to "{}"

--- a/pokemonterminal/wallpaper/adapters/darwin.py
+++ b/pokemonterminal/wallpaper/adapters/darwin.py
@@ -1,0 +1,28 @@
+from . import WallpaperProvider as _WProv
+import subprocess as __sp
+import sys as __sys
+
+
+class DarwinProvider(_WProv):
+    __osa_script_fmt = """tell application "System Events"
+    \ttell current desktop
+    \t\tset picture to "{}"
+    \tend tell
+    end tell"""
+
+    def __run_osascript(stream):
+        p = __sp.Popen(['osascript'], stdout=__sp.PIPE,
+                       stdin=__sp.PIPE)
+        p.stdin.write(stream)
+        p.communicate()
+        p.stdin.close()
+
+    def change_wallpaper(path: str) -> None:
+        script = DarwinProvider.__osa_script_fmt.format(path)
+        DarwinProvider.__run_osascript(str.encode(script))
+
+    def is_compatible() -> bool:
+        return __sys.platform == "darwin"
+
+    def __str__():
+        return "MacOS Desktop Environment"

--- a/pokemonterminal/wallpaper/adapters/darwin.py
+++ b/pokemonterminal/wallpaper/adapters/darwin.py
@@ -1,9 +1,9 @@
-from . import WallpaperProvider as __WProv
-import subprocess as __sp
-import sys as __sys
+from . import WallpaperProvider as _WProv
+import subprocess as _sp
+import sys as _sys
 
 
-class DarwinProvider(__WProv):
+class DarwinProvider(_WProv):
     __osa_script_fmt = """tell application "System Events"
     \ttell current desktop
     \t\tset picture to "{}"
@@ -11,8 +11,8 @@ class DarwinProvider(__WProv):
     end tell"""
 
     def __run_osascript(stream):
-        p = __sp.Popen(['osascript'], stdout=__sp.PIPE,
-                       stdin=__sp.PIPE)
+        p = _sp.Popen(['osascript'], stdout=__sp.PIPE,
+                      stdin=__sp.PIPE)
         p.stdin.write(stream)
         p.communicate()
         p.stdin.close()
@@ -22,7 +22,7 @@ class DarwinProvider(__WProv):
         DarwinProvider.__run_osascript(str.encode(script))
 
     def is_compatible() -> bool:
-        return __sys.platform == "darwin"
+        return _sys.platform == "darwin"
 
     def __str__():
         return "MacOS Desktop Environment"

--- a/pokemonterminal/wallpaper/adapters/darwin.py
+++ b/pokemonterminal/wallpaper/adapters/darwin.py
@@ -11,8 +11,8 @@ class DarwinProvider(_WProv):
     end tell"""
 
     def __run_osascript(stream):
-        p = _sp.Popen(['osascript'], stdout=__sp.PIPE,
-                      stdin=__sp.PIPE)
+        p = _sp.Popen(['osascript'], stdout=_sp.PIPE,
+                      stdin=_sp.PIPE)
         p.stdin.write(stream)
         p.communicate()
         p.stdin.close()

--- a/pokemonterminal/wallpaper/adapters/gnome.py
+++ b/pokemonterminal/wallpaper/adapters/gnome.py
@@ -1,14 +1,14 @@
-from . import WallpaperProvider as _WProv
-import os as _os
+from . import WallpaperProvider as __WProv
+import os as __os
 
 
-class GnomeProvider(_WProv):
+class GnomeProvider(__WProv):
     def change_wallpaper(path: str) -> None:
-        _os.system('gsettings set org.gnome.desktop.background ' +
-                   f'picture-uri "file://{path}"')
+        __os.system('gsettings set org.gnome.desktop.background ' +
+                    f'picture-uri "file://{path}"')
 
     def is_compatible() -> bool:
-        return "gnome" in _os.environ.get("GDMSESSION")
+        return "gnome" in __os.environ.get("GDMSESSION")
 
     def __str__():
         return "GNOME Shell Desktop"

--- a/pokemonterminal/wallpaper/adapters/gnome.py
+++ b/pokemonterminal/wallpaper/adapters/gnome.py
@@ -8,8 +8,7 @@ class GnomeProvider(_WProv):
                    f'picture-uri "file://{path}"')
 
     def is_compatible() -> bool:
-        return (_os.environ.get("GDMSESSION") is not None and
-                "gnome" in _os.environ.get("GDMSESSION").lower())
+        return "gnome" in _os.environ.get("GDMSESSION", default='').lower()
 
     def __str__():
         return "GNOME Shell Desktop"

--- a/pokemonterminal/wallpaper/adapters/gnome.py
+++ b/pokemonterminal/wallpaper/adapters/gnome.py
@@ -8,7 +8,8 @@ class GnomeProvider(_WProv):
                    f'picture-uri "file://{path}"')
 
     def is_compatible() -> bool:
-        return "gnome" in _os.environ.get("GDMSESSION")
+        return (_os.environ.get("GDMSESSION") is not None and
+                "gnome" in _os.environ.get("GDMSESSION").lower())
 
     def __str__():
         return "GNOME Shell Desktop"

--- a/pokemonterminal/wallpaper/adapters/gnome.py
+++ b/pokemonterminal/wallpaper/adapters/gnome.py
@@ -1,0 +1,14 @@
+from . import WallpaperProvider as _WProv
+import os as _os
+
+
+class GnomeProvider(_WProv):
+    def change_wallpaper(path: str) -> None:
+        _os.system('gsettings set org.gnome.desktop.background ' +
+                   f'picture-uri "file://{path}"')
+
+    def is_compatible() -> bool:
+        return "gnome" in _os.environ.get("GDMSESSION")
+
+    def __str__():
+        return "GNOME Shell Desktop"

--- a/pokemonterminal/wallpaper/adapters/gnome.py
+++ b/pokemonterminal/wallpaper/adapters/gnome.py
@@ -1,14 +1,14 @@
-from . import WallpaperProvider as __WProv
-import os as __os
+from . import WallpaperProvider as _WProv
+import os as _os
 
 
-class GnomeProvider(__WProv):
+class GnomeProvider(_WProv):
     def change_wallpaper(path: str) -> None:
-        __os.system('gsettings set org.gnome.desktop.background ' +
-                    f'picture-uri "file://{path}"')
+        _os.system('gsettings set org.gnome.desktop.background ' +
+                   f'picture-uri "file://{path}"')
 
     def is_compatible() -> bool:
-        return "gnome" in __os.environ.get("GDMSESSION")
+        return "gnome" in _os.environ.get("GDMSESSION")
 
     def __str__():
         return "GNOME Shell Desktop"

--- a/tests/test_wallpaper.py
+++ b/tests/test_wallpaper.py
@@ -1,0 +1,16 @@
+from pokemonterminal.wallpaper import _get_adapter_classes
+import os.path as __p
+import inspect as __inspct
+
+
+def test_wallpaper_adapter_classes():
+    all_adapter = _get_adapter_classes()
+    files = {__inspct.getfile(x) for x in all_adapter}
+    print('all adapter classes:\n', files)
+    assert len(all_adapter) >= len(files), \
+        "Some of the files in the adapter module don't define an adapter"
+    module_name = {x.__name__: __p.splitext(__p.basename(
+        __inspct.getfile(x)))[0] for x in all_adapter}
+    print("'class: module' map\n", module_name)
+    assert all(y.lower() in x.lower() for x, y in module_name.items()), \
+        "Some of the adapters are defined in unrelated named modules"


### PR DESCRIPTION
Continues the discussion from #129 
So I changed the structure a little to help with the reflection it's currently on the following structure
```text
pokemonterminal/wallpaper
├── adapters
│   ├── darwin.py
│   ├── gnome.py
│   └── __init__.py
└── __init__.py
```
It is already 100% functional on Gnome, I tried my best not to break the Mac implementation but I can't really be sure since I don't have one to test... 

Also I couldn't come up with no better tests than `assert constant == 'constant'`  any ideas on what to test? 