### PR TITLE
Fix -c does not clear the background in Tilix

### DIFF
--- a/pokemonterminal/terminal/adapters/tilix.py
+++ b/pokemonterminal/terminal/adapters/tilix.py
@@ -17,7 +17,7 @@ class TilixProvider(_TProv):
                                  path))
 
     def clear():
-        command = 'gsettings set {} {}'
+        command = 'gsettings reset {} {}'
         os.system(command.format(TilixProvider.setting_key,
                                  TilixProvider.setting_field))
 


### PR DESCRIPTION
'pokemon -c' does not clear the background in Tilix, since it does not give VALUE aregument.