### PR TITLE
iTerm2 applescript fix

### DIFF
--- a/pokemonterminal/terminal/adapters/iterm.py
+++ b/pokemonterminal/terminal/adapters/iterm.py
@@ -6,7 +6,7 @@ from . import TerminalProvider as _TProv
 
 class ItermProvider(_TProv):
     # OSA script that will change the terminal background image
-    osa_script_fmt = """tell application "iTerm"
+    osa_script_fmt = """tell application "iTerm2"
     \ttell current session of current window
     \t\tset background image to "{}"
     \tend tell


### PR DESCRIPTION
After some recent system/app updates (not exactly sure which) I started getting the following error:
`43:50: syntax error: Expected end of line but found identifier. (-2741)`. This was coming from the applescript.
Updated to use same naming as used in the iTerm2 scripting docs https://www.iterm2.com/documentation-scripting.html which resolves the error.