### PR TITLE
Initial Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Install Python 3.6 or higher:
 
 Get a compatible terminal emulator:
 - [iTerm2](https://iterm2.com/)
-- [ConEmu](https://conemu.github.io/) and derivates such as [Cmder](http://cmder.net/)
+- [ConEmu](https://conemu.github.io/) and derivatives such as [Cmder](http://cmder.net/)
 - [Terminology](https://www.enlightenment.org/about-terminology)
 - [Tilix](https://gnunn1.github.io/tilix-web/)
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - Select Pokemon by name or by index number
 - Ability to change the Desktop Wallpaper & the Terminal background
 - Internal search system for finding Pokemon
-- Supports iTerm2, ConEmu, Terminology & Tilix terminal emulators
+- Supports iTerm2, ConEmu, Terminology and Tilix terminal emulators
 - Supports MacOS, GNOME, and i3wm (with feh) for desktops
 - Windows support for Terminal background setting (without slideshow)  
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 - Ability to change the Desktop Wallpaper & the Terminal background
 - Internal search system for finding Pokemon
 - Supports iTerm2, ConEmu, Terminology and Tilix terminal emulators
-- Supports MacOS, GNOME, and i3wm (with feh) for desktops
+- Supports MacOS, GNOME, Openbox (with feh), and i3wm (with feh) for desktops
 - Windows support for Terminal background setting (without slideshow)  
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -36,19 +36,22 @@
 - Select Pokemon by name or by index number
 - Ability to change the Desktop Wallpaper & the Terminal background
 - Internal search system for finding Pokemon
-- Supports iTerm2, Terminology & Tilix terminal emulators
+- Supports iTerm2, ConEmu, Terminology & Tilix terminal emulators
 - Supports MacOS, GNOME, and i3wm (with feh) for desktops
+- Windows support for Terminal background setting (without slideshow)  
 
 # Installation
 
 Install Python 3.6 or higher:
 - [For Mac](https://www.python.org/downloads/mac-osx/)
+- [For Windows](https://www.python.org/downloads/windows/)
 - [For Ubuntu](https://askubuntu.com/a/865569)
 - [For Arch Linux](https://www.archlinux.org/packages/extra/x86_64/python/)
 - Not all compatible distros are named here, but a quick Google search should give you instructions for your distribution of choice.
 
 Get a compatible terminal emulator:
 - [iTerm2](https://iterm2.com/)
+- [ConEmu](https://conemu.github.io/) and derivates such as [Cmder](http://cmder.net/)
 - [Terminology](https://www.enlightenment.org/about-terminology)
 - [Tilix](https://gnunn1.github.io/tilix-web/)
 
@@ -156,6 +159,14 @@ The result should look like this:
 
 ![](https://i.imgur.com/82DAT97.jpg)
 
+## ConEmu settings
+
+1. From the menu under the symbol at left of title bar, navigate to Settings > Main > Background
+2. Set Darkening to maximum (255).
+3. Set Placement to Stretch.
+4. Click Save Settings.
+5. Optionally you apply transparency under Features > Transparency.
+
 ## Adding Custom Images
 
 The folder `pokemonterminal/Images/Extra` is for adding custom images. You can manually add backgrounds to this folder and they will be visible to the program. Only JPG format is supported. To see a list of all the custom backgrounds type:
@@ -191,6 +202,9 @@ I have not yet implemented a way to save the terminal background to a profile. T
 4. You can leave out `; clear` if you don't care about the line showing up at the top of the terminal.
 
 ![](https://i.imgur.com/2d4qa9j.png)
+
+### Windows
+After setting your desired pokemon, from the menu under the symbol at left of title bar, navigate to Settings > Main > Background and click Save Settings.
 
 ### Linux
 Terminology already saves it automatically, just untick "temporary" in the settings after setting your desired Pokemon:

--- a/ichooseyou
+++ b/ichooseyou
@@ -1,1 +1,0 @@
-pokemon

--- a/pokemon
+++ b/pokemon
@@ -1,8 +1,0 @@
-#!/usr/bin/env python3.6
-
-import sys
-
-from pokemonterminal.main import main
-
-
-main(sys.argv[1:])

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -118,6 +118,9 @@ def main(argv=None):
         return
 
     if is_slideshow and options.id <= 0 and size > 1:
+        if os.name == 'nt':
+            print("Slideshow not supported on Windows yet.")
+            sys.exit(0)
         if PIPE_EXISTS:
             print("Slideshow already running in this instance!")
             sys.exit(0)
@@ -130,6 +133,9 @@ def main(argv=None):
         return
 
     if options.wallpaper:
+        if os.name == 'nt':
+            print("Setting wallpaper not supported on Windows yet.")
+            sys.exit(0)
         scripter.change_wallpaper(target.get_path())
     else:
         scripter.change_terminal(target.get_path())

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -12,7 +12,7 @@ from pokemonterminal.command_flags import parser, is_slideshow
 from pokemonterminal.database import Database
 from pokemonterminal.filters import Filter
 
-PIPE_PATH = os.path.join(os.path.expanduser('~'), "/.pokemon-terminal-pipe" + str(os.getppid()))
+PIPE_PATH = os.path.join(os.path.expanduser('~'), ".pokemon-terminal-pipe" + str(os.getppid()))
 PIPE_EXISTS = os.path.exists(PIPE_PATH)
 
 

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -12,7 +12,7 @@ from pokemonterminal.command_flags import parser, is_slideshow
 from pokemonterminal.database import Database
 from pokemonterminal.filters import Filter
 
-PIPE_PATH = os.environ["HOME"] + "/.pokemon-terminal-pipe" + str(os.getppid())
+PIPE_PATH = os.path.join(os.path.expanduser('~'), "/.pokemon-terminal-pipe" + str(os.getppid()))
 PIPE_EXISTS = os.path.exists(PIPE_PATH)
 
 

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -6,13 +6,14 @@ import random
 import sys
 import time
 from multiprocessing import Process
+from pathlib import Path
 
 from . import scripter
 from pokemonterminal.command_flags import parser, is_slideshow
 from pokemonterminal.database import Database
 from pokemonterminal.filters import Filter
 
-PIPE_PATH = os.path.join(os.path.expanduser('~'), ".pokemon-terminal-pipe" + str(os.getppid()))
+PIPE_PATH = Path.home() / (".pokemon-terminal-pipe" + str(os.getppid()))
 PIPE_EXISTS = os.path.exists(PIPE_PATH)
 
 

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -55,7 +55,7 @@ def slideshow(filtered, delay, changer_func):
         p.join(delay * 60)
 
 
-def main(argv):
+def main(argv=None):
     """Entrance to the program."""
     if __name__ != "__main__":
         Filter.filtered_list = [pok for pok in Filter.POKEMON_LIST]

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -134,9 +134,6 @@ def main(argv=None):
         return
 
     if options.wallpaper:
-        if os.name == 'nt':
-            print("Setting wallpaper not supported on Windows yet.")
-            sys.exit(0)
         scripter.change_wallpaper(target.get_path())
     else:
         scripter.change_terminal(target.get_path())

--- a/pokemonterminal/terminal/adapters/conemu.py
+++ b/pokemonterminal/terminal/adapters/conemu.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 import sys
 
 from . import TerminalProvider as _TProv

--- a/pokemonterminal/terminal/adapters/conemu.py
+++ b/pokemonterminal/terminal/adapters/conemu.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+from . import TerminalProvider as _TProv
+
+
+class ConEmuProvider(_TProv):
+
+    def is_compatible() -> bool:
+        return "CONEMUPID" in os.environ
+
+    def change_terminal(path: str):
+        subprocess.run(['ConEmuC', '-GuiMacro', 'SetOption("Background Image", "{}")'.format(path)], check=True)
+
+    def clear():
+        subprocess.run(['ConEmuC', '-GuiMacro', 'SetOption("Background Image", "")'], check=True)
+
+    def __str__():
+        return "ConEmu"

--- a/pokemonterminal/terminal/adapters/conemu.py
+++ b/pokemonterminal/terminal/adapters/conemu.py
@@ -11,10 +11,16 @@ class ConEmuProvider(_TProv):
         return "CONEMUPID" in os.environ
 
     def change_terminal(path: str):
-        subprocess.run(['ConEmuC', '-GuiMacro', 'SetOption("Background Image", "{}")'.format(path)], check=True)
+        # ConEmu has issues with the quoting when using an arg list, so use shell=True
+        # ConEmu requires the image path to have escaped slashes. Enforce this by converting all slashes in the path to
+        # backlashes, replace all previously doubled slashes with a single slash, then replace all single slashes with
+        # double backslash
+        cmd = 'ConEmuC -GuiMacro SetOption("Background Image", "{}")'.format(os.path.normpath(path).replace(
+            '\\\\', '\\').replace('\\', '\\\\'))
+        subprocess.run(cmd, shell=True, check=True)
 
     def clear():
-        subprocess.run(['ConEmuC', '-GuiMacro', 'SetOption("Background Image", "")'], check=True)
+        subprocess.run('ConEmuC -GuiMacro SetOption("Background Image", "")', shell=True, check=True)
 
     def __str__():
         return "ConEmu"

--- a/pokemonterminal/wallpaper/adapters/feh.py
+++ b/pokemonterminal/wallpaper/adapters/feh.py
@@ -1,8 +1,10 @@
-from . import WallpaperProvider as _WProv
+import subprocess
+import sys
 from os import system
 from pathlib import Path
 from shutil import which
-import subprocess
+
+from . import WallpaperProvider as _WProv
 
 
 class FehProvider(_WProv):
@@ -10,6 +12,8 @@ class FehProvider(_WProv):
         system(f'feh --no-fehbg --bg-fill "{path}"')
 
     def is_compatible() -> bool:
+        if not sys.platform.startswith('linux'):
+            return False
         root_window_prop = str(subprocess.check_output('xprop -root -notype', shell=True))
         return which("feh") is not None and \
             (Path.home() / '.fehbg').is_file() and \

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,12 @@ Supports ITerm2, Terminology & Tilix.""",
         "pokemonterminal": package_data("pokemonterminal", ["Data", "Images"]),
     },
 
-    scripts=['pokemon', 'ichooseyou'],
+    entry_points = {
+        'console_scripts': [
+            'pokemon = pokemonterminal.main:main',
+            'ichooseyou = pokemonterminal.main:main',
+        ],
+    },
 
     keywords="pokemon terminal theme style pokemon-terminal",
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ Pokemon Terminal Themes.
 from Kanto, Johto, Hoenn, Sinnoh, Unova, and Kalos.
 
 Change the Terminal Background & Desktop Wallpaper.
-Supports ITerm2, Terminology & Tilix.""",
+Supports ITerm2, Terminology, Tilix, & ConEmu.""",
     url="https://github.com/LazoCoder/Pokemon-Terminal",
 
     author="LazoCoder",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ Pokemon Terminal Themes.
 from Kanto, Johto, Hoenn, Sinnoh, Unova, and Kalos.
 
 Change the Terminal Background & Desktop Wallpaper.
-Supports ITerm2, Terminology, Tilix, & ConEmu.""",
+Supports ITerm2, Terminology, Tilix and ConEmu.""",
     url="https://github.com/LazoCoder/Pokemon-Terminal",
 
     author="LazoCoder",

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     long_description="""
 Pokemon Terminal Themes.
 
-493 unique Pokemon.
-from Kanto, Johto, Hoenn and Sinnoh.
+719 unique Pokemon.
+from Kanto, Johto, Hoenn, Sinnoh, Unova, and Kalos.
 
 Change the Terminal Background & Desktop Wallpaper.
 Supports ITerm2, Terminology & Tilix.""",


### PR DESCRIPTION
Supports setting terminal background when using ConEmu or derivative terminal emulators on Windows.

No slideshow support - I figured out how to do this, but it is not clean. Since windows has no `fork`, it is required to start the daemon process using python's `multiprocessing` module. Communicating with it in order to stop it is another challenge as Windows doesn't have named pipes, and no support for `os.mkfifo()`. The solution I came up with involved replacing the named pipe with a socket and using socket communication instead. As mentioned it worked, but I'm not happy with some of the implementation and workarounds that had to be used, so I'm not submitting it here.
No wallpaper setting either - I haven't looked into this but I imagine it's probably not too difficult but it's windows so everything is usually more challenging than it should be 😛 
`main()` just exits with an appropriate message if an unsupported option is given