### PR TITLE
add filepath argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Misc:
   -dr, --dry-run        Implies -v and doesn't actually changes either
                         wallpaper or background after the pokemon has been
                         chosen
+  -fp, --filepath       Identical to --dry-run, but prints only the filepath
+                        of the chosen image. Useful for scripting
 
 Not setting any filters will get a completely random pokemon
 ```

--- a/pokemonterminal/command_flags.py
+++ b/pokemonterminal/command_flags.py
@@ -95,6 +95,12 @@ _misc_group.add_argument(
     help='Implies -v and doesn\'t actually changes either wallpaper '
     'or background after the pokemon has been chosen',
     action='store_true')
+_misc_group.add_argument(
+    '-fp',
+    '--filepath',
+    help='Identical to --dry-run, but prints only the filepath of the chosen image. Useful for scripting',
+    action='store_true'
+)
 either = parser.add_mutually_exclusive_group()
 either.add_argument(
     '-c',

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -69,6 +69,10 @@ def main(argv=None):
         print("Dry run, exiting.")
         return
 
+    if options.filepath:
+        print(target.get_path())
+        return
+
     event_name = "Pokemon-Terminal_Wallpaper" if options.wallpaper else "Pokemon-Terminal_Terminal"
     event_exists = PlatformNamedEvent.exists(event_name)
 


### PR DESCRIPTION
This PR adds a -fp/--filepath argument which is identical to --dry-run, but instead of printing a name it simply prints the filepath to the randomly-chosen image. This way, you can use Pokemon-Terminal's filters and conveniences with any background setter or for any other purpose (with the proper scripting)!