### PR TITLE
Fixed bug: Clearing when there's no current terminal background no longer results in KeyError.

### DIFF
--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -76,10 +76,7 @@ def main(argv=None):
         if event_exists:
             slideshow.stop(event_name)
         if not options.wallpaper:
-            try:
-                scripter.clear_terminal()
-            except KeyError:
-                print("There's no current background to clear.")
+            scripter.clear_terminal()
         return
 
     if is_slideshow and options.id <= 0 and size > 1:

--- a/pokemonterminal/main.py
+++ b/pokemonterminal/main.py
@@ -76,7 +76,10 @@ def main(argv=None):
         if event_exists:
             slideshow.stop(event_name)
         if not options.wallpaper:
-            scripter.clear_terminal()
+            try:
+                scripter.clear_terminal()
+            except KeyError:
+                print("There's no current background to clear.")
         return
 
     if is_slideshow and options.id <= 0 and size > 1:

--- a/pokemonterminal/terminal/adapters/windowsterminal.py
+++ b/pokemonterminal/terminal/adapters/windowsterminal.py
@@ -24,7 +24,10 @@ class WindowsTerminalProvider(_TProv):
             # update defaults profile
             profile = profiles['defaults']
             if (path is None):
-                del profile['backgroundImage']
+                if 'backgroundImage' in profile:
+                    del profile['backgroundImage']
+                else:
+                    print("There is no background to clear.")
             else:
                 profile['backgroundImage'] = path
 

--- a/pokemonterminal/terminal/adapters/windowsterminal.py
+++ b/pokemonterminal/terminal/adapters/windowsterminal.py
@@ -23,11 +23,8 @@ class WindowsTerminalProvider(_TProv):
             
             # update defaults profile
             profile = profiles['defaults']
-            if (path is None):
-                if 'backgroundImage' in profile:
-                    del profile['backgroundImage']
-                else:
-                    print("There is no background to clear.")
+            if path is None and 'backgroundImage' in profile:
+                del profile['backgroundImage']
             else:
                 profile['backgroundImage'] = path
 


### PR DESCRIPTION
Currently, if the user tries to input "pokemon -c" when there is no current terminal background, a KeyError is caused. 
![Screenshot 2024-04-03 111610](https://github.com/LazoCoder/Pokemon-Terminal/assets/59585764/ca8a6d9f-8b02-4154-880f-b4c78c913eb4)

I added a simple try/except block to print out "There is no background to clear." to account for this.
![Screenshot 2024-04-03 111747](https://github.com/LazoCoder/Pokemon-Terminal/assets/59585764/b74427a8-3551-4d54-afe7-c3c11418de99)

This also works for slideshow clearing too.