### PR TITLE
Fix issue #197: Ctrl+C interrupt no longer causes Traceback error when slideshow is cleared

### DIFF
--- a/pokemonterminal/slideshow.py
+++ b/pokemonterminal/slideshow.py
@@ -16,17 +16,20 @@ def __get_listener_thread(event):
 
 def __slideshow_worker(filtered, delay, changer_func, event_name):
     with PlatformNamedEvent(event_name) as e:
-        t = __get_listener_thread(e)
-        random.shuffle(filtered)
-        queque = iter(filtered)
-        while t.is_alive():
-            next_pkmn = next(queque, None)
-            if next_pkmn is None:
-                random.shuffle(filtered)
-                queque = iter(filtered)
-                continue
-            changer_func(next_pkmn.get_path())
-            t.join(delay * 60)
+        try:
+            t = __get_listener_thread(e)
+            random.shuffle(filtered)
+            queque = iter(filtered)
+            while t.is_alive():
+                next_pkmn = next(queque, None)
+                if next_pkmn is None:
+                    random.shuffle(filtered)
+                    queque = iter(filtered)
+                    continue
+                changer_func(next_pkmn.get_path())
+                t.join(delay * 60)
+        except KeyboardInterrupt:
+            pass
 
 def start(filtered, delay, changer_func, event_name):
     p = multiprocessing.Process(target=__slideshow_worker, args=(filtered, delay, changer_func, event_name, ), daemon=True)


### PR DESCRIPTION
In response to Issue#197:
When a slideshow is running, if the user holds down Ctrl+C (Keyboard Interrupt) and then proceeds to clear the slideshow using the -c flag, a Traceback occurs and is printed to the Terminal:
![Screenshot 2024-04-03 105422](https://github.com/LazoCoder/Pokemon-Terminal/assets/59585764/f1e3d309-0a3c-4e89-928a-46eca227d5fb)

I added a try/except block to catch when a Keyboard Interrupt occurs. Now, if the user clears the slideshow, no Traceback is printed:
![Screenshot 2024-04-03 105751](https://github.com/LazoCoder/Pokemon-Terminal/assets/59585764/687d436b-7144-4e02-8a19-7f24d757e0b0)
