### PR TITLE
Add swww wallpaper adapter

### DIFF
--- a/pokemonterminal/wallpaper/adapters/swww.py
+++ b/pokemonterminal/wallpaper/adapters/swww.py
@@ -1,0 +1,22 @@
+from subprocess import run
+from shutil import which
+from . import WallpaperProvider as _WProv
+
+
+class SwwwProvider(_WProv):
+    def change_wallpaper(path: str):
+        run(["swww", "img", path], check=True)
+        
+    def is_compatible() -> bool:
+        # check if swww is installed
+        if not which("swww"):
+            return False
+
+        # check if it's working (i.e. the daemon is running)
+        if run(["swww", "query"], capture_output=True).returncode != 0:
+            return False
+
+        return True
+
+    def __str__():
+        return "swww"


### PR DESCRIPTION
This adds an adapter for the [swww](https://github.com/LGFae/swww) wallpaper daemon. For checking compatibility it both checks if `swww` is present, and also if the daemon is running (I sometimes install a boatload of tools that I don't actually actively use, so it's important to me to check for this case as well :D)